### PR TITLE
Fix .deepsource.toml configuration

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,9 +4,6 @@ version = 1
 name = "javascript"
 enabled = true
 
-[analyzers.meta]
-runtime_version = "22"
-
 [[analyzers]]
 name = "sql"
 enabled = true


### PR DESCRIPTION
## Summary
- remove invalid `runtime_version` from DeepSource config

## Testing
- `npm test` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68448f024c608323a9aef7600f3ef2b1